### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Phoenix Toggl
-[Toggl](http://toggl.com) tribute done with [Elixir](https://github.com/elixir-lang/elixir), [Phoenix Framework](https://github.com/phoenixframework/phoenix), [React](https://github.com/facebook/react) and [Redux](https://github.com/rackt/redux).
+[Toggl](https://toggl.com/) tribute done with [Elixir](https://github.com/elixir-lang/elixir), [Phoenix Framework](https://github.com/phoenixframework/phoenix), [React](https://github.com/facebook/react) and [Redux](https://github.com/reactjs/redux).
 
 ![`timer`](http://codeloveandboards.com/images/blog/toggl_tribute/timer-e9b1582f.jpg)
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/rackt/redux | https://github.com/reactjs/redux 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://toggl.com | https://toggl.com/ 
